### PR TITLE
close: delete an image for a spot

### DIFF
--- a/backend/routes/api/index.js
+++ b/backend/routes/api/index.js
@@ -5,6 +5,7 @@ const usersRouter = require('./users.js');
 const spotsRouter = require('./spots.js');
 const bookingsRouter = require('./bookings.js');
 const reviewsRouter = require('./reviews.js');
+const spotImagesRouter = require('./spot-images.js');
 
 const { restoreUser } = require('../../utils/auth.js');
 
@@ -18,6 +19,7 @@ router.use('/users', usersRouter);
 router.use('/spots', spotsRouter);
 router.use('/bookings', bookingsRouter);
 router.use('/reviews', reviewsRouter);
+router.use('/spot-images', spotImagesRouter);
 
 router.post('/test', function (req, res) {
     res.json({ requestBody: req.body });

--- a/backend/routes/api/spot-images.js
+++ b/backend/routes/api/spot-images.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const { requireAuth } = require('../../utils/auth');
+const { SpotImage } = require('../../db/models');
+const router = express.Router();
+
+router.delete('/:spotId', requireAuth, async (req, res) => {
+    const { spotId } = req.params;
+
+    const spotImageToDelete = await SpotImage.findByPk(spotId);
+    if (!spotImageToDelete)
+        return res.status(404).json({ message: "Spot Image couldn't be found" });
+
+    if (req.user.id !== spotImageToDelete.userId)
+        return res.status(403).json({ message: 'Forbidden' });
+
+    await spotImageToDelete.destroy();
+    res.status.json({
+        message: 'Successfully deleted',
+    });
+});
+
+module.exports = router;


### PR DESCRIPTION
Delete an existing image for a Spot.

- [x] An authenticated user is required for a successful response
- [x] Only the owner of the spot is authorized to delete
- [x] Image record is removed from the database after request
- [x] Success response includes a `message` indicating a successful deletion
- [x] Error response with status 404 is given when a spot image does not exist
  with the provided `id`
